### PR TITLE
Improve Gatling Highcharts reporting

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -7,7 +7,7 @@
                  [org.clojure/core.async "1.3.622"]
                  [http-kit "2.5.3"]
                  [prismatic/schema "1.1.12"]
-                 [clojider-gatling-highcharts-reporter "0.3.1"]]
+                 [clojider-gatling-highcharts-reporter "0.3.2"]]
   :profiles {:dev {:global-vars {*warn-on-reflection* false}
                    :source-paths ["examples"]
                    :dependencies [[clj-time "0.15.2"]

--- a/src/clj_gatling/simulation.clj
+++ b/src/clj_gatling/simulation.clj
@@ -15,16 +15,20 @@
 (defn- now [] (System/currentTimeMillis))
 
 (defn asynchronize [f ctx]
-  (let [parse-response (fn [result]
-                         (if (vector? result)
-                           {:result (first result) :end-time (now) :context (second result)}
-                           {:result result :end-time (now) :context ctx}))]
+  (let [parse-result   (fn [result]
+                         (if (instance? Exception result)
+                           {:result false :exception result}
+                           {:result result}))
+        parse-response (fn [response]
+                         (if (vector? response)
+                           (assoc (parse-result (first response)) :end-time (now) :context (second response))
+                           (assoc (parse-result response) :end-time (now) :context ctx)))]
     (go
       (try
-        (let [result (f ctx)]
-          (if (instance? clojure.core.async.impl.channels.ManyToManyChannel result)
-            (parse-response (<! result))
-            (parse-response result)))
+        (let [response (f ctx)]
+          (if (instance? clojure.core.async.impl.channels.ManyToManyChannel response)
+            (parse-response (<! response))
+            (parse-response response)))
         (catch Exception e
           {:result false :end-time (now) :context ctx :exception e})))))
 
@@ -47,8 +51,8 @@
                        :result result
                        :context-after context) context]
         [(assoc return :end (now)
-                       :exception exception
-                       :return false
+                       :exception (ex-info "request timed out" {:timeout-in-ms timeout})
+                       :result false
                        :context-after original-context-with-user)
          original-context-with-user]))))
 
@@ -107,8 +111,7 @@
           (do
             (when post-hook
               (post-hook context))
-            (>! result-channel (->> (dissoc result :exception)
-                                    (conj results))))
+            (>! result-channel (conj results result)))
           (recur next-steps (conj results result)))))
     result-channel))
 


### PR DESCRIPTION
This uses the modifications to the Gatling Highcharts reporter
(mhjort/clojider-gatling-highcharts-reporter#2)
to record a breakdown of the types of failure that occur. User-defined
request functions simply need to throw the exception for this to be
triggered.

Given that some libraries (e.g. `httpkit`) return a clojure
ExceptionInfo in a failed response it is also useful to check the
response for a directly returned exception object, rather than requiring
it to be thrown.